### PR TITLE
Patch 1 fix apollo webhooks

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -31,8 +31,8 @@ export default {
   plugins: [
     {
       src: '~plugins/apollo.js',
-      mode: 'client',
-    },
+      mode: 'client'
+    }
   ],
   /*
   ** Nuxt.js dev-modules

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -29,7 +29,10 @@ export default {
   ** Plugins to load before mounting the App
   */
   plugins: [
-    '~plugins/apollo.js'
+    {
+      src: '~plugins/apollo.js',
+      mode: 'client',
+    },
   ],
   /*
   ** Nuxt.js dev-modules


### PR DESCRIPTION
Changes apollo websocket authorization plugin to client-side only. Apparently nuxt-apollo doesn't create the wsClient on the server side (which makes sense).

Fixes #1 